### PR TITLE
add alternate route for `commands` response

### DIFF
--- a/src/hyperdeck/parser.js
+++ b/src/hyperdeck/parser.js
@@ -19,7 +19,7 @@ function convertDataToObject(data) {
   dataObject.text = text;
 
    if (firstLineMatches[3] === ":") {
-    if (dataObject.text == "commands") {
+    if (text == "commands") {
       //this response is all XML and doesn't match the other response structures
       var params = {};
       params['response'] == data;

--- a/src/hyperdeck/parser.js
+++ b/src/hyperdeck/parser.js
@@ -18,17 +18,23 @@ function convertDataToObject(data) {
   dataObject.code = code;
   dataObject.text = text;
 
-  if (firstLineMatches[3] === ":") {
-    // the response has parameters on following lines
-    var params = {};
-    //Append the rest into an object for emitting.
-    lines.forEach(function(line) {
-      var lineData = /^(.*)\: (.*)$/.exec(line);
-      //First element in array is the whole string.
-      if(lineData) {
-        params[lineData[1]] = lineData[2];
-      }
-    });
+   if (firstLineMatches[3] === ":") {
+    if (dataObject.text == "commands") {
+      //this response is all XML and doesn't match the other response structures
+      var params = {};
+      params['response'] == data;
+    } else {
+      // the response has parameters on following lines
+      var params = {};
+      //Append the rest into an object for emitting.
+      lines.forEach(function (line) {
+          var lineData = /^(.*)\: (.*)$/.exec(line);
+          //First element in array is the whole string.
+          if (lineData) {
+            params[lineData[1]] = lineData[2];
+          }
+        }
+      });
     dataObject.params = params;
   }
   return dataObject;


### PR DESCRIPTION
the response doesn't match the normal formatting of 
```
{Response code} {Response text}:
{Parameter}: {Value}
{Parameter}: {Value}
...
```

This addresses #36

**This needs testing** 