### PR TITLE
add rawData to response

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ hyperdeck.slotInfo(); //Gives info on currently selected slot
 hyperdeck.slotInfo(1);
 hyperdeck.clipsGet();
 hyperdeck.transportInfo();
+hyperdeck.format(format);
 ```
 
 # API Documentation

--- a/README.md
+++ b/README.md
@@ -19,7 +19,9 @@ The response is an object with the following properties:
 - `code`: The nuemeric response code.
 - `text`: The response text.
 
-It may contain another key `params` which will be an object where the keys are the parameter keys in the response, and the values are the corresponding values in the response. If the response from the hyperdeck doesn't support parameters this key won't exist.
+If the response from the hyperdeck also contains data the following keys will also exist:
+- `rawData`: A string which contains the unparsed data.
+- `params`: An object where the keys are the parameter keys in the response, and the values are the corresponding values in the response. This is best-effort, and if the response is not structured in the params format shown in the documentation, may be an empty object. It will try to parse each line in the response individually.
 
 ```javascript
 var HyperdeckLib = require("hyperdeck-js-lib");

--- a/src/hyperdeck/hyperdeck.js
+++ b/src/hyperdeck/hyperdeck.js
@@ -61,6 +61,15 @@ var Hyperdeck = function(ip) {
     return this.makeRequest("slot select: slot id: " + id);
   };
 
+  this.format = function(format){
+    return this.makeRequest("format: prepare: " + format).then(function(response){
+      if (response.code !== 216 || response.text !== "format ready" || !response.rawData) {
+        throw new Error("Unexpected response.");
+      }
+      var token = response.rawData;
+      return this.makeRequest("format: confirm: " + token);
+    });
+  };
 };
 
 // make this class extend HyperdeckCore

--- a/src/hyperdeck/parser.js
+++ b/src/hyperdeck/parser.js
@@ -19,7 +19,12 @@ function convertDataToObject(data) {
   dataObject.text = text;
 
   if (firstLineMatches[3] === ":") {
-    // the response has parameters on following lines
+    // the response has data on following lines
+    // provide the raw data in addition to attempting to parse the response into params
+    dataObject.rawData = lines.slice(0, lines.length-1).join("\r\n");
+
+    // this is a best effort. Some of the responses (e.g 'commands'), do not return
+    // the usual format, and in this case params will likely remain as {}
     var params = {};
     //Append the rest into an object for emitting.
     lines.forEach(function(line) {

--- a/src/hyperdeck/parser.js
+++ b/src/hyperdeck/parser.js
@@ -17,14 +17,16 @@ function convertDataToObject(data) {
   var text = firstLineMatches[2];
   dataObject.code = code;
   dataObject.text = text;
-
-  if (firstLineMatches[3] === ":") {
-    // the response has data on following lines
+  
+  if (lines.length) {
     // provide the raw data in addition to attempting to parse the response into params
-    dataObject.rawData = lines.slice(0, lines.length-1).join("\r\n");
-
-    // this is a best effort. Some of the responses (e.g 'commands'), do not return
-    // the usual format, and in this case params will likely remain as {}
+    dataObject.rawData = lines.slice(0, lines.length-2).join("\r\n");
+  }
+  
+  if (firstLineMatches[3] === ":") {
+    // the response should have params on the next lines
+    // (although sometimes it doesn't because of the responses (e.g 'commands'), do not return
+    // the usual format, and in this case params will likely remain as {})
     var params = {};
     //Append the rest into an object for emitting.
     lines.forEach(function(line) {

--- a/test/hyperdeck/parser.js
+++ b/test/hyperdeck/parser.js
@@ -21,7 +21,7 @@ var SUCCESS_PARAMS_RESPONSE_DATA = {
     data: {
         code: 200,
         text: "Success with data",
-        rawData: 'something: 123\r\nsomething else: test\r\n',
+        rawData: 'something: 123\r\nsomething else: test',
         params: {
             something: "123",
             "something else": "test"
@@ -34,7 +34,7 @@ var SUCCESS_UNPARSEABLE_PARAMS_RESPONSE_DATA = {
     data: {
         code: 200,
         text: "Success with data",
-        rawData: '<something-unexpected />\r\n',
+        rawData: '<something-unexpected />',
         params: {}
     }
 };
@@ -52,7 +52,7 @@ var FAILURE_PARAMS_RESPONSE_DATA = {
     data: {
         code: 102,
         text: "Failure",
-        rawData: "something: 123\r\nsomething else: test\r\n",
+        rawData: "something: 123\r\nsomething else: test",
         params:  {
             something: "123",
             "something else": "test"
@@ -65,7 +65,7 @@ var ASYNC_RESPONSE_DATA = {
     data: {
         code: 512,
         text: "Async event",
-        rawData: "protocol version: 9.5\r\nmodel: xyz\r\ntime: 12:40:12\r\n",
+        rawData: "protocol version: 9.5\r\nmodel: xyz\r\ntime: 12:40:12",
         params: {
             "protocol version": "9.5",
             model: "xyz",

--- a/test/hyperdeck/parser.js
+++ b/test/hyperdeck/parser.js
@@ -2,6 +2,7 @@ var Parser = require('../../src/hyperdeck/parser');
 
 var SUCCESS_RESPONSE = "200 Success";
 var SUCCESS_RESPONSE_WITH_PARAMS = "200 Success with data:\r\nsomething: 123\r\nsomething else: test\r\n\r\n";
+var SUCCESS_RESPONSE_WITH_UNPARSEABLE_PARAMS = "200 Success with data:\r\n<something-unexpected />\r\n\r\n";
 var FAILURE_RESPONSE = "102 Failure";
 var FAILURE_RESPONSE_WITH_PARAMS = "102 Failure:\r\nsomething: 123\r\nsomething else: test\r\n\r\n";
 var ASYNC_RESPONSE = "512 Async event:\r\nprotocol version: 9.5\r\nmodel: xyz\r\ntime: 12:40:12\r\n\r\n";
@@ -20,10 +21,21 @@ var SUCCESS_PARAMS_RESPONSE_DATA = {
     data: {
         code: 200,
         text: "Success with data",
+        rawData: 'something: 123\r\nsomething else: test\r\n',
         params: {
             something: "123",
             "something else": "test"
         }
+    }
+};
+
+var SUCCESS_UNPARSEABLE_PARAMS_RESPONSE_DATA = {
+    type: "synchronousSuccess",
+    data: {
+        code: 200,
+        text: "Success with data",
+        rawData: '<something-unexpected />\r\n',
+        params: {}
     }
 };
 
@@ -40,6 +52,7 @@ var FAILURE_PARAMS_RESPONSE_DATA = {
     data: {
         code: 102,
         text: "Failure",
+        rawData: "something: 123\r\nsomething else: test\r\n",
         params:  {
             something: "123",
             "something else": "test"
@@ -52,6 +65,7 @@ var ASYNC_RESPONSE_DATA = {
     data: {
         code: 512,
         text: "Async event",
+        rawData: "protocol version: 9.5\r\nmodel: xyz\r\ntime: 12:40:12\r\n",
         params: {
             "protocol version": "9.5",
             model: "xyz",
@@ -86,6 +100,10 @@ describe('Parser', function() {
     (function() {
         Parser.parse(INVALID_RESPONSE);
     }).should.throw();
+  });
+
+  it('should handle a response string with a success status code and unparseable params', function() {
+    Parser.parse(SUCCESS_RESPONSE_WITH_UNPARSEABLE_PARAMS).should.eql(SUCCESS_UNPARSEABLE_PARAMS_RESPONSE_DATA);
   });
 
 });

--- a/test/hyperdeck/response-handler.js
+++ b/test/hyperdeck/response-handler.js
@@ -6,7 +6,7 @@ var SUCCESS_RESPONSE_EVENT_PAYLOAD = {
   data: {
     code: 200,
     text: "Success with data",
-    rawData: "something: 123\r\nsomething else: test\r\n",
+    rawData: "something: 123\r\nsomething else: test",
     params: {
       something: "123",
       "something else": "test"
@@ -20,7 +20,7 @@ var FAILURE_RESPONSE_EVENT_PAYLOAD = {
   data: {
     code: 102,
     text: "Failure",
-    rawData: "something: 123\r\nsomething else: test\r\n",
+    rawData: "something: 123\r\nsomething else: test",
     params: {
       something: "123",
       "something else": "test"
@@ -32,7 +32,7 @@ var ASYNC_RESPONSE = "512 Async event:\r\nprotocol version: 9.5\r\nmodel: xyz\r\
 var ASYNC_RESPONSE_EVENT_PAYLOAD = {
   code: 512,
   text: "Async event",
-  rawData: "protocol version: 9.5\r\nmodel: xyz\r\ntime: 12:40:12\r\n",
+  rawData: "protocol version: 9.5\r\nmodel: xyz\r\ntime: 12:40:12",
   params: {
     "protocol version": "9.5",
     model: "xyz",

--- a/test/hyperdeck/response-handler.js
+++ b/test/hyperdeck/response-handler.js
@@ -6,6 +6,7 @@ var SUCCESS_RESPONSE_EVENT_PAYLOAD = {
   data: {
     code: 200,
     text: "Success with data",
+    rawData: "something: 123\r\nsomething else: test\r\n",
     params: {
       something: "123",
       "something else": "test"
@@ -19,6 +20,7 @@ var FAILURE_RESPONSE_EVENT_PAYLOAD = {
   data: {
     code: 102,
     text: "Failure",
+    rawData: "something: 123\r\nsomething else: test\r\n",
     params: {
       something: "123",
       "something else": "test"
@@ -30,6 +32,7 @@ var ASYNC_RESPONSE = "512 Async event:\r\nprotocol version: 9.5\r\nmodel: xyz\r\
 var ASYNC_RESPONSE_EVENT_PAYLOAD = {
   code: 512,
   text: "Async event",
+  rawData: "protocol version: 9.5\r\nmodel: xyz\r\ntime: 12:40:12\r\n",
   params: {
     "protocol version": "9.5",
     model: "xyz",


### PR DESCRIPTION
This enables commands like 'commands', which don't return data in the documented params format, to be used in applicatons, as they can use the 'rawData' property instead.