### PR TITLE
use status code to determine if multiple lines expected

### DIFF
--- a/src/hyperdeck/parser.js
+++ b/src/hyperdeck/parser.js
@@ -1,18 +1,20 @@
+var FIRST_LINE_REGEX = /^([0-9]+) (.+?)(\:?)$/;
+var PARAMS_REGEX = /^(.*)\: (.*)$/;
+
 /**
  * Converts the data to a Object.
  * So the hyperdeck class can do things nicely with it.
  * @return dataObject, The data in a nice object. This will contain "code", "text" and "params" keys,
  *                     (if there are parameters) where params is an object.
  **/
-function convertDataToObject(data) {
+function convertDataToObject(lines) {
   var dataObject = {
     code: null,
     text: null
   };
 
-  var lines = data.split("\r\n"); //Splits the data on a new line.
   var firstLine = lines.shift(); // should contain {Response code} {Response text}
-  var firstLineMatches = /^([0-9]+) (.+?)(\:?)$/.exec(firstLine);
+  var firstLineMatches = FIRST_LINE_REGEX.exec(firstLine);
   var code = parseInt(firstLineMatches[1]);
   var text = firstLineMatches[2];
   dataObject.code = code;
@@ -20,7 +22,7 @@ function convertDataToObject(data) {
   
   if (lines.length) {
     // provide the raw data in addition to attempting to parse the response into params
-    dataObject.rawData = lines.slice(0, lines.length-2).join("\r\n");
+    dataObject.rawData = lines.join("\r\n");
   }
   
   if (firstLineMatches[3] === ":") {
@@ -30,7 +32,7 @@ function convertDataToObject(data) {
     var params = {};
     //Append the rest into an object for emitting.
     lines.forEach(function(line) {
-      var lineData = /^(.*)\: (.*)$/.exec(line);
+      var lineData = PARAMS_REGEX.exec(line);
       //First element in array is the whole string.
       if(lineData) {
         params[lineData[1]] = lineData[2];
@@ -44,38 +46,38 @@ function convertDataToObject(data) {
 /**
  * Parses responses from the hyperdeck into a nice object.
  */
- function failureResponseCode(data) {
+ function failureResponseCode(lines) {
    return {
      type: "synchronousFailure",
-     data: convertDataToObject(data)
+     data: convertDataToObject(lines)
    };
  }
 
- function successResponseCode(data) {
+ function successResponseCode(lines) {
    return {
      type: "synchronousSuccess",
-     data: convertDataToObject(data)
+     data: convertDataToObject(lines)
    };
  }
 
- function asynchornousResponseCode(data) {
+ function asynchornousResponseCode(lines) {
    return {
      type: "asynchronous",
-     data: convertDataToObject(data)
+     data: convertDataToObject(lines)
    };
  }
 
 var Parser = {
 
-  parse: function(data) {
+  parse: function(lines) {
     // pass into the switch/case to decide which function to use.
-    switch (data.charAt(0)){
+    switch (lines[0].charAt(0)){
       case "1":
-        return failureResponseCode(data);
+        return failureResponseCode(lines);
       case "2":
-        return successResponseCode(data);
+        return successResponseCode(lines);
       case "5":
-        return asynchornousResponseCode(data);
+        return asynchornousResponseCode(lines);
       default:
         throw new Error("Invalid payload. Unknown response code.");
     }

--- a/src/hyperdeck/response-handler.js
+++ b/src/hyperdeck/response-handler.js
@@ -4,62 +4,84 @@ var Logger = require("../logger");
 
 var logger = Logger.get("hyperdeck.ResponseHandler");
 
+var SINGLE_LINE_REGEX = /^(?:1\d{2}|200) /;
+
 /**
  * Handles responses from they hyperdeck.
  */
 function ResponseHandler(clientSocket) {
   var destroyed = false;
   var notifier = new events.EventEmitter();
-  var buffer = "";
-  
-  function isBufferComplete() {
-    var lines = buffer.split("\r\n");
-    // there will always be an empty element at the end as every line will always end in "\r\n"
-    // so remove it.
-    // i.e. "1\r\n2\r\n" => ["1", "2", ""]
-    lines.pop();
-    if (lines.length === 1) {
-      // is it a single line response?
-      return lines[0].indexOf(":") !== lines[0].length-1;
-    } 
-    // multi line response so waiting for a blank line to signify end
-    return lines[lines.length-1] === "";
+  var buffer = [];
+  var incompleteLastLine = '';
+
+  function isRespComplete() {
+    var complete = false;
+    if (buffer.length === 1) {
+      // a single line response
+      // 1XX and 200 is always single line response
+      complete = SINGLE_LINE_REGEX.test(buffer[0]);
+    } else {
+      // multi line response, so waiting for a blank line to signify end
+      complete = buffer[buffer.length - 1] === '';
+    }
+    return complete;
   }
-  
+
   function onData(rawData) {
-    buffer += rawData;
-    if (!isBufferComplete()) {
-      return;
-    }
-    logger.debug('Got data on socket.', rawData);
-    var data = Parser.parse(buffer);
-    // reset buffer
-    buffer = "";
-  
-    switch (data.type) {
-      case "synchronousFailure":
-      case "synchronousSuccess":
-        var response = {
-          success: data.type === "synchronousSuccess",
-          data: data.data
-        };
-        notifier.emit("synchronousResponse", response);
-        break;
-      case "asynchronous":
-        notifier.emit("asynchronousResponse", data.data);
-        break;
-      default:
-        throw "Unknown response type.";
-    }
+    logger.debug('Got data on socket.\n', rawData);
+    var resArray = (incompleteLastLine + rawData).split('\r\n');
+    incompleteLastLine = resArray.pop();
+    resArray.forEach(function (line) {
+      // push to buffer till response is read completly
+      // handle empty lines before the data
+      // see https://github.com/LA1TV/Hyperdeck-JS-Lib/issues/44
+      if (buffer.length > 0 || (buffer.length === 0 && line.trim() !== '')) {
+        buffer.push(line);
+        if (isRespComplete()) {
+          if (buffer.length > 1) {
+            // multiline response, remove empty line
+            buffer.pop();
+          }
+
+          logger.debug('Got complete data.\n', buffer);
+          // reset buffer here and use clone (in case exception happens below)
+          var bufferClone = buffer.splice(0);
+          try {
+            var data = Parser.parse(bufferClone);
+            switch (data.type) {
+              case "synchronousFailure":
+              case "synchronousSuccess":
+                var response = {
+                  success: data.type === "synchronousSuccess",
+                  data: data.data
+                };
+                notifier.emit("synchronousResponse", response);
+                break;
+              case "asynchronous":
+                notifier.emit("asynchronousResponse", data.data);
+                break;
+              default:
+                throw new Error("Unknown response type.");
+            }
+          } catch(e) {
+            // defer exception so that we don't stop processing response
+            setTimeout(function() {
+              throw e;
+            }, 0);
+          }
+        }
+      }
+    });
   }
 
   clientSocket.on('data', onData);
 
-  this.getNotifier = function() {
+  this.getNotifier = function () {
     return notifier;
   };
 
-  this.destroy = function() {
+  this.destroy = function () {
     if (destroyed) {
       return;
     }

--- a/test/hyperdeck/hyperdeck-core.js
+++ b/test/hyperdeck/hyperdeck-core.js
@@ -14,7 +14,7 @@ var ASYNCHRONOUS_EVENT_DATA = {
   }
 };
 var SUCCESS_DATA = {
-  code: 200,
+  code: 201,
   text: "Success with data",
   params: {
     something: "123",

--- a/test/hyperdeck/parser.js
+++ b/test/hyperdeck/parser.js
@@ -1,25 +1,36 @@
 var Parser = require('../../src/hyperdeck/parser');
 
-var SUCCESS_RESPONSE = "200 Success";
-var SUCCESS_RESPONSE_WITH_PARAMS = "200 Success with data:\r\nsomething: 123\r\nsomething else: test\r\n\r\n";
-var SUCCESS_RESPONSE_WITH_UNPARSEABLE_PARAMS = "200 Success with data:\r\n<something-unexpected />\r\n\r\n";
-var FAILURE_RESPONSE = "102 Failure";
-var FAILURE_RESPONSE_WITH_PARAMS = "102 Failure:\r\nsomething: 123\r\nsomething else: test\r\n\r\n";
-var ASYNC_RESPONSE = "512 Async event:\r\nprotocol version: 9.5\r\nmodel: xyz\r\ntime: 12:40:12\r\n\r\n";
-var INVALID_RESPONSE = "something invalid";
+var SUCCESS_RESPONSE = [ '200 ok' ];
+var SUCCESS_RESPONSE_WITH_PARAMS = [
+    '201 Success with data:',
+    'something: 123',
+    'something else: test'
+];
+var SUCCESS_RESPONSE_WITH_UNPARSEABLE_PARAMS = [
+    '201 Success with data:',
+    '<something-unexpected />'
+];
+var FAILURE_RESPONSE = [ '102 Failure' ];
+var ASYNC_RESPONSE = [
+    '512 Async event:',
+    'protocol version: 9.5',
+    'model: xyz',
+    'time: 12:40:12'
+];
+var INVALID_RESPONSE = [ 'something invalid' ];
 
 var SUCCESS_RESPONSE_DATA = {
     type: "synchronousSuccess",
     data: {
         code: 200,
-        text: "Success"
+        text: "ok"
     }
 };
 
 var SUCCESS_PARAMS_RESPONSE_DATA = {
     type: "synchronousSuccess",
     data: {
-        code: 200,
+        code: 201,
         text: "Success with data",
         rawData: 'something: 123\r\nsomething else: test',
         params: {
@@ -32,7 +43,7 @@ var SUCCESS_PARAMS_RESPONSE_DATA = {
 var SUCCESS_UNPARSEABLE_PARAMS_RESPONSE_DATA = {
     type: "synchronousSuccess",
     data: {
-        code: 200,
+        code: 201,
         text: "Success with data",
         rawData: '<something-unexpected />',
         params: {}
@@ -86,10 +97,6 @@ describe('Parser', function() {
 
   it('should handle a response string with a failure status code', function() {
     Parser.parse(FAILURE_RESPONSE).should.eql(FAILURE_RESPONSE_DATA);
-  });
-
-  it('should handle a response string with a failure status code and params', function() {
-    Parser.parse(FAILURE_RESPONSE_WITH_PARAMS).should.eql(FAILURE_PARAMS_RESPONSE_DATA);
   });
 
   it('should handle a response string with an async status code', function() {


### PR DESCRIPTION
We now use the status code to determine if there are muliple lines, instead of checking for the `:`. We treat 1xx and 200 as single line responses and expect everything else to be multiline.

We also refactored the parser which improves overall performance, and correctly handle if the data arrives in random segments. There is a test that checks we can handle a response arriving character by character.

fixes #44 

based off #46
closes #46 and #45 